### PR TITLE
Ext jb 4.1 set box height

### DIFF
--- a/extension/genome-browser/src/app/react-components/JbrowseWrapper.tsx
+++ b/extension/genome-browser/src/app/react-components/JbrowseWrapper.tsx
@@ -36,23 +36,10 @@ function JbrowserWrapper(props: any) {
               MuiPaper: {
                 styleOverrides: {
                   root:{
-                    boxShadow: "none",
-                    // height: "200px",
-                    // overflow: "auto",
-                    // borderRadius: "0px",
-                    // padding: "0 !important",
-                    // margin: "0px"
+                    boxShadow: "none"
                   }
                 }
-              },
-              // MuiAppBar: {
-              //   styleOverrides: {
-              //     root: {
-              //       boxShadow: "none",
-              //       height: "45px"
-              //     }
-              //   }
-              // }
+              }
             }
       
           }


### PR DESCRIPTION
## Description
Set jbrowse container height to constant height

## Changes
- Use div style to set container height in JbrowseWrapper.tsx

## Comments for testing
- height currently set to 200px - could be changed to 250px??
- Currently MVP - when scrolling within the container, the jbrowse header is not pinned to the top and becomes hidden from view