### PR TITLE
Add gene models feature track

### DIFF
--- a/extension/genome-browser/src/app/react-components/tracks.ts
+++ b/extension/genome-browser/src/app/react-components/tracks.ts
@@ -1,4 +1,26 @@
 export default [
+    {
+        "type": "FeatureTrack",
+        "trackId": "ITAG2.4 Gene Models",
+        "name": "ITAG2.4 Gene Models",
+        "adapter": {
+          "type": "Gff3TabixAdapter",
+          "gffGzLocation": {
+            "uri": "http://localhost:4200/TersectBrowserGP/tbapi/datafiles/ITAG2.4_gene_models.sorted.gff3.gz",
+            "locationType": "UriLocation"
+          },
+          "index": {
+            "location": {
+              "uri": "http://localhost:4200/TersectBrowserGP/tbapi/datafiles/ITAG2.4_gene_models.sorted.gff3.gz.tbi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "TBI"
+          }
+        },
+        "assemblyNames": [
+          "SL2.50"
+        ]
+      },
       {
           "type": "VariantTrack",
           "trackId": "S.lyc LA2706",


### PR DESCRIPTION
## Description
Added gene models track to JBrowse window

## Changes
- Add a `FeatureTrack` containing the ITAG2.4 gene model track to `tracks.ts`

## Comments for testing
The files `ITAG2.4_gene_models.sorted.gff3.gz` and `ITAG2.4_gene_models.sorted.gff3.gz.tbi` need to be hosted in the `gp_data_copy` folder. From Monday 7th April, these files will be present in the `gp_data_copy` folder on elvis